### PR TITLE
Fixing score_card not found error

### DIFF
--- a/R/plot_component.R
+++ b/R/plot_component.R
@@ -88,7 +88,7 @@ plot_component <- function(score_table,
                           by= c("component","indicator","reporting_scale"))
 
   #tidy data for plotting. This involves expanding each observation (indicator*class) times 3, to fill out the doughnut. Creating new categories for when grade is missing(W) and for the interior of the doughnut (Z).
-  plot_table <-  prepare_doughnut_chart(plot_table = plot_table)
+  plot_table <-  prepare_doughnut_chart(plot_table = plot_table,score_table=score_table)
 
   #if no color table is provided, then use these colors
   if(is.null(color_table)){

--- a/R/prepare_doughnut_chart.R
+++ b/R/prepare_doughnut_chart.R
@@ -8,7 +8,7 @@
 #
 #' @export
 
-prepare_doughnut_chart <- function(plot_table){
+prepare_doughnut_chart <- function(plot_table,score_table){
 
 
   plot_table <- plot_table %>%


### PR DESCRIPTION
Pass the custom score_card in from plot_component to prepare_doughnut_chart, or the standard one will be found in the global environment and used instead inappropriately.